### PR TITLE
fix: rendering contact items

### DIFF
--- a/src/components/contact-list/contact-list.js
+++ b/src/components/contact-list/contact-list.js
@@ -17,10 +17,25 @@ export class ContactList extends ChatMessage {
   }
 
   render(filteredContacts) {
+    // @todo quick hardcoded hack:
+    // just remove all children
+    if (this.children.length > 0) {
+      console.log('removing rendered children');
+      for (let i = this.children.length - 1; i >= 0; i -= 1) {
+        this.children[i].remove();
+      }
+    }
+
+    // @todo compare rendered children
+    // remove unnecessary ones
+    // add required ones
+    // utilise attribute (like this.rendered etc.)
+
     const fragment = new DocumentFragment();
 
     for (const item of filteredContacts) {
       const element = document.createElement('div');
+      // element.id = `item-${item._id}`;
       element.classList.add('contact-item');
       element.innerHTML = createItemHtml(item);
       fragment.append(element);


### PR DESCRIPTION
Items of the contact list were rendered twice.
Fixed it (temporary) by (always) removing rendered items.